### PR TITLE
Feature: Add soft delete functionality for stories

### DIFF
--- a/frontend/src/hooks/useStories.ts
+++ b/frontend/src/hooks/useStories.ts
@@ -314,6 +314,52 @@ export function useStoryOperations() {
     }
   }, [session?.accessToken]);
 
+  const deleteStory = useCallback(async (id: string) => {
+    if (!session?.accessToken) {
+      setError('You must be logged in to delete a story');
+      return false;
+    }
+    
+    setLoading(true);
+    setError(null);
+    setErrorDetails(null);
+    setSuccess(false);
+    
+    try {
+      console.log('Deleting story:', { id });
+      
+      await apiClient.stories.delete(id, session.accessToken);
+      
+      setSuccess(true);
+      return true;
+    } catch (err) {
+      console.error('Error deleting story:', err);
+      
+      if (err instanceof ApiRequestError) {
+        const errMsg = err.status === 401 
+          ? handleAuthError(err) 
+          : err.message;
+        
+        setError(errMsg);
+        setErrorDetails({
+          status: err.status,
+          data: err.data,
+          requestDetails: err.requestDetails
+        });
+      } else {
+        setError('Failed to delete story');
+        setErrorDetails(err instanceof Error ? {
+          message: err.message,
+          stack: err.stack
+        } : err);
+      }
+      
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.accessToken]);
+
   const saveStory = useCallback(async (storyData: Partial<Story>, shouldRedirect = true) => {
     try {
       let result = null;
@@ -351,6 +397,7 @@ export function useStoryOperations() {
     success,
     createStory,
     updateStory,
+    deleteStory,
     saveStory,
   };
 } 


### PR DESCRIPTION
- Backend: Add DELETE /stories/{id} endpoint with soft delete (sets deleted=true)
- Update all queries to exclude deleted stories (deleted != true)
- Frontend: Add deleteStory function to useStories hook
- Landing page: Show delete button only for unpublished stories when logged in
- Editor page: Show delete button for all stories when editing
- UI: Add confirmation dialogs and loading states

Fixes #19