### PR TITLE
fix: Add comprehensive www subdomain support for OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ GOOGLE_CLIENT_SECRET=
 NEXTAUTH_SECRET=
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_DEBUG=true
+# For production, set to .ghostmonk.com to support both www and non-www subdomains
+NEXTAUTH_COOKIE_DOMAIN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,17 @@ Required environment variables in `.env`:
 - Google Cloud Storage (`GCS_BUCKET_NAME`, `GOOGLE_APPLICATION_CREDENTIALS`)
 - Google OAuth (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`)
 - NextAuth (`NEXTAUTH_SECRET`, `NEXTAUTH_URL`)
+- **For www subdomain support**: `NEXTAUTH_COOKIE_DOMAIN=.ghostmonk.com` (production only)
 
 Place `gcp-credentials.json` in project root.
+
+### Google OAuth Configuration
+
+For www subdomain support, ensure both redirect URIs are configured in Google Cloud Console:
+- `https://ghostmonk.com/api/auth/callback/google`  
+- `https://www.ghostmonk.com/api/auth/callback/google`
+
+In production, set `NEXTAUTH_COOKIE_DOMAIN=.ghostmonk.com` to enable cross-subdomain cookie sharing.
 
 ## Key Implementation Details
 

--- a/frontend/src/pages/api/auth/[...nextauth].ts
+++ b/frontend/src/pages/api/auth/[...nextauth].ts
@@ -21,6 +21,70 @@ export const authOptions: NextAuthOptions = {
             return session;
         },
     },
+    cookies: {
+        sessionToken: {
+            name: `next-auth.session-token`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: process.env.NODE_ENV === 'production',
+                domain: process.env.NEXTAUTH_COOKIE_DOMAIN || undefined,
+            },
+        },
+        callbackUrl: {
+            name: `next-auth.callback-url`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: process.env.NODE_ENV === 'production',
+                domain: process.env.NEXTAUTH_COOKIE_DOMAIN || undefined,
+            },
+        },
+        csrfToken: {
+            name: `next-auth.csrf-token`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: process.env.NODE_ENV === 'production',
+                domain: process.env.NEXTAUTH_COOKIE_DOMAIN || undefined,
+            },
+        },
+        pkceCodeVerifier: {
+            name: `next-auth.pkce.code_verifier`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: process.env.NODE_ENV === 'production',
+                maxAge: 900,
+                domain: process.env.NEXTAUTH_COOKIE_DOMAIN || undefined,
+            },
+        },
+        state: {
+            name: `next-auth.state`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: process.env.NODE_ENV === 'production',
+                maxAge: 900,
+                domain: process.env.NEXTAUTH_COOKIE_DOMAIN || undefined,
+            },
+        },
+        nonce: {
+            name: `next-auth.nonce`,
+            options: {
+                httpOnly: true,
+                sameSite: 'lax',
+                path: '/',
+                secure: process.env.NODE_ENV === 'production',
+                domain: process.env.NEXTAUTH_COOKIE_DOMAIN || undefined,
+            },
+        },
+    },
     secret: process.env.NEXTAUTH_SECRET,
     debug: process.env.NEXTAUTH_DEBUG === 'true',
 };


### PR DESCRIPTION
Configure NextAuth.js cookies to work across subdomains by:
- Setting explicit cookie domain configuration for all OAuth cookies
- Adding NEXTAUTH_COOKIE_DOMAIN environment variable support
- Updating documentation with Google OAuth redirect URI requirements

This fixes the "State cookie was missing" error when users login via www.ghostmonk.com by ensuring the OAuth state cookie is accessible across both www and non-www subdomains.

Fixes #10

🤖 Generated with [Claude Code](https://claude.ai/code)